### PR TITLE
Update littlefs to version 1.6

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,19 +1,24 @@
-Copyright (c) 2017 Christopher Haster
+Copyright (c) 2017, Arm Limited. All rights reserved.
 
-Permission is hereby granted, free of charge, to any person obtaining a
-copy of this software and associated documentation files (the "Software"),
-to deal in the Software without restriction, including without limitation
-the rights to use, copy, modify, merge, publish, distribute, sublicense,
-and/or sell copies of the Software, and to permit persons to whom the
-Software is furnished to do so, subject to the following conditions:
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
 
-The above copyright notice and this permission notice shall be included in
-all copies or substantial portions of the Software.
+-  Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+-  Redistributions in binary form must reproduce the above copyright notice, this
+   list of conditions and the following disclaimer in the documentation and/or
+   other materials provided with the distribution.
+-  Neither the name of ARM nor the names of its contributors may be used to
+   endorse or promote products derived from this software without specific prior
+   written permission.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
-THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-DEALINGS IN THE SOFTWARE.
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/lfs_fuse.c
+++ b/lfs_fuse.c
@@ -1,8 +1,8 @@
 /*
  * FUSE wrapper for the littlefs
  *
- * Copyright (c) 2017 Christopher Haster
- * Distributed under the MIT license
+ * Copyright (c) 2017, Arm Limited. All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #define FUSE_USE_VERSION 26

--- a/lfs_fuse_bd.c
+++ b/lfs_fuse_bd.c
@@ -12,7 +12,7 @@
 #include <stdint.h>
 #include <assert.h>
 #if !defined(__FreeBSD__)
-#include <stropts.h>
+#include <sys/ioctl.h>
 #include <linux/fs.h>
 #elif defined(__FreeBSD__)
 #define BLKSSZGET DIOCGSECTORSIZE

--- a/lfs_fuse_bd.c
+++ b/lfs_fuse_bd.c
@@ -1,8 +1,8 @@
 /*
  * Linux user-space block device wrapper
  *
- * Copyright (c) 2017 Christopher Haster
- * Distributed under the MIT license
+ * Copyright (c) 2017, Arm Limited. All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 #include "lfs_fuse_bd.h"
 

--- a/lfs_fuse_bd.h
+++ b/lfs_fuse_bd.h
@@ -1,8 +1,8 @@
 /*
  * Linux user-space block device wrapper
  *
- * Copyright (c) 2017 Christopher Haster
- * Distributed under the MIT license
+ * Copyright (c) 2017, Arm Limited. All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 #ifndef LFS_FUSE_BD_H
 #define LFS_FUSE_BD_H

--- a/littlefs/.gitignore
+++ b/littlefs/.gitignore
@@ -1,0 +1,9 @@
+# Compilation output
+*.o
+*.d
+*.a
+
+# Testing things
+blocks/
+lfs
+test.c

--- a/littlefs/.travis.yml
+++ b/littlefs/.travis.yml
@@ -1,107 +1,215 @@
+# Environment variables
 env:
+  global:
     - CFLAGS=-Werror
 
+# Common test script
 script:
-    # make sure example can at least compile
-    - sed -n '/``` c/,/```/{/```/d; p;}' README.md > test.c &&
-      make all size CFLAGS+="
+  # make sure example can at least compile
+  - sed -n '/``` c/,/```/{/```/d; p;}' README.md > test.c &&
+    make all CFLAGS+="
         -Duser_provided_block_device_read=NULL
         -Duser_provided_block_device_prog=NULL
         -Duser_provided_block_device_erase=NULL
         -Duser_provided_block_device_sync=NULL
         -include stdio.h"
 
-    # run tests
-    - make test QUIET=1
+  # run tests
+  - make test QUIET=1
 
-    # run tests with a few different configurations
-    - make test QUIET=1 CFLAGS+="-DLFS_READ_SIZE=1      -DLFS_PROG_SIZE=1"
-    - make test QUIET=1 CFLAGS+="-DLFS_READ_SIZE=512    -DLFS_PROG_SIZE=512"
-    - make test QUIET=1 CFLAGS+="-DLFS_BLOCK_COUNT=1023 -DLFS_LOOKAHEAD=2048"
+  # run tests with a few different configurations
+  - make test QUIET=1 CFLAGS+="-DLFS_READ_SIZE=1      -DLFS_PROG_SIZE=1"
+  - make test QUIET=1 CFLAGS+="-DLFS_READ_SIZE=512    -DLFS_PROG_SIZE=512"
+  - make test QUIET=1 CFLAGS+="-DLFS_BLOCK_COUNT=1023 -DLFS_LOOKAHEAD=2048"
+
+  - make clean test QUIET=1 CFLAGS+="-DLFS_NO_INTRINSICS"
+
+  # compile and find the code size with the smallest configuration
+  - make clean size
+        OBJ="$(ls lfs*.o | tr '\n' ' ')"
+        CFLAGS+="-DLFS_NO_ASSERT -DLFS_NO_DEBUG -DLFS_NO_WARN -DLFS_NO_ERROR"
+        | tee sizes
+
+  # update status if we succeeded, compare with master if possible
+  - |
+    if [ "$TRAVIS_TEST_RESULT" -eq 0 ]
+    then
+        CURR=$(tail -n1 sizes | awk '{print $1}')
+        PREV=$(curl -u $GEKY_BOT_STATUSES https://api.github.com/repos/$TRAVIS_REPO_SLUG/status/master \
+            | jq -re "select(.sha != \"$TRAVIS_COMMIT\")
+                | .statuses[] | select(.context == \"$STAGE/$NAME\").description
+                | capture(\"code size is (?<size>[0-9]+)\").size" \
+            || echo 0)
+
+        STATUS="Passed, code size is ${CURR}B"
+        if [ "$PREV" -ne 0 ]
+        then
+            STATUS="$STATUS ($(python -c "print '%+.2f' % (100*($CURR-$PREV)/$PREV.0)")%)"
+        fi
+    fi
+
+# CI matrix
+jobs:
+  include:
+    # native testing
+    - stage: test
+      env:
+        - STAGE=test
+        - NAME=littlefs-x86
+
+    # cross-compile with ARM (thumb mode)
+    - stage: test
+      env:
+        - STAGE=test
+        - NAME=littlefs-arm
+        - CC="arm-linux-gnueabi-gcc --static -mthumb"
+        - EXEC="qemu-arm"
+      install:
+        - sudo apt-get install gcc-arm-linux-gnueabi qemu-user
+        - arm-linux-gnueabi-gcc --version
+        - qemu-arm -version
+
+    # cross-compile with PowerPC
+    - stage: test
+      env:
+        - STAGE=test
+        - NAME=littlefs-powerpc
+        - CC="powerpc-linux-gnu-gcc --static"
+        - EXEC="qemu-ppc"
+      install:
+        - sudo apt-get install gcc-powerpc-linux-gnu qemu-user
+        - powerpc-linux-gnu-gcc --version
+        - qemu-ppc -version
+
+    # cross-compile with MIPS
+    - stage: test
+      env:
+        - STAGE=test
+        - NAME=littlefs-mips
+        - CC="mips-linux-gnu-gcc --static"
+        - EXEC="qemu-mips"
+      install:
+        - sudo add-apt-repository -y "deb http://archive.ubuntu.com/ubuntu/ xenial main universe"
+        - sudo apt-get -qq update
+        - sudo apt-get install gcc-mips-linux-gnu qemu-user
+        - mips-linux-gnu-gcc --version
+        - qemu-mips -version
 
     # self-host with littlefs-fuse for fuzz test
-    - make -C littlefs-fuse
+    - stage: test
+      env:
+        - STAGE=test
+        - NAME=littlefs-fuse
+      install:
+        - sudo apt-get install libfuse-dev
+        - git clone --depth 1 https://github.com/geky/littlefs-fuse
+        - fusermount -V
+        - gcc --version
+      before_script:
+        # setup disk for littlefs-fuse
+        - rm -rf littlefs-fuse/littlefs/*
+        - cp -r $(git ls-tree --name-only HEAD) littlefs-fuse/littlefs
 
-    - littlefs-fuse/lfs --format /dev/loop0
-    - littlefs-fuse/lfs /dev/loop0 mount
+        - mkdir mount
+        - sudo chmod a+rw /dev/loop0
+        - dd if=/dev/zero bs=512 count=2048 of=disk
+        - losetup /dev/loop0 disk
+      script:
+        # self-host test
+        - make -C littlefs-fuse
 
-    - ls mount
-    - mkdir mount/littlefs
-    - cp -r $(git ls-tree --name-only HEAD) mount/littlefs
-    - cd mount/littlefs
-    - ls
-    - make -B test_dirs test_files QUIET=1
+        - littlefs-fuse/lfs --format /dev/loop0
+        - littlefs-fuse/lfs /dev/loop0 mount
 
+        - ls mount
+        - mkdir mount/littlefs
+        - cp -r $(git ls-tree --name-only HEAD) mount/littlefs
+        - cd mount/littlefs
+        - ls
+        - make -B test_dirs test_files QUIET=1
+
+      # Automatically update releases
+    - stage: deploy
+      env:
+        - STAGE=deploy
+        - NAME=deploy
+      script:
+        # Find version defined in lfs.h
+        - LFS_VERSION=$(grep -ox '#define LFS_VERSION .*' lfs.h | cut -d ' ' -f3)
+        - LFS_VERSION_MAJOR=$((0xffff & ($LFS_VERSION >> 16)))
+        - LFS_VERSION_MINOR=$((0xffff & ($LFS_VERSION >>  0)))
+        # Grab latests patch from repo tags, default to 0
+        - LFS_VERSION_PATCH=$(curl -f -u "$GEKY_BOT_RELEASES"
+                https://api.github.com/repos/$TRAVIS_REPO_SLUG/git/refs
+                | jq 'map(.ref | match(
+                    "refs/tags/v'"$LFS_VERSION_MAJOR"'\\.'"$LFS_VERSION_MINOR"'\\.(.*)$")
+                    .captures[].string | tonumber + 1) | max // 0')
+        # We have our new version
+        - LFS_VERSION="v$LFS_VERSION_MAJOR.$LFS_VERSION_MINOR.$LFS_VERSION_PATCH"
+        - echo "VERSION $LFS_VERSION"
+        - |
+          # Check that we're the most recent commit
+          CURRENT_COMMIT=$(curl -f -u "$GEKY_BOT_RELEASES" \
+                https://api.github.com/repos/$TRAVIS_REPO_SLUG/commits/master \
+                | jq -re '.sha')
+          if [ "$TRAVIS_COMMIT" == "$CURRENT_COMMIT" ]
+          then
+            # Build release notes
+            PREV=$(git tag --sort=-v:refname -l "v*" | head -1)
+            if [ ! -z "$PREV" ]
+            then
+                echo "PREV $PREV"
+                CHANGES=$'### Changes\n\n'$( \
+                    git log --oneline $PREV.. --grep='^Merge' --invert-grep)
+                printf "CHANGES\n%s\n\n" "$CHANGES"
+            fi
+            # Create the release
+            curl -f -u "$GEKY_BOT_RELEASES" -X POST \
+                https://api.github.com/repos/$TRAVIS_REPO_SLUG/releases \
+                -d "{
+                    \"tag_name\": \"$LFS_VERSION\",
+                    \"target_commitish\": \"$TRAVIS_COMMIT\",
+                    \"name\": \"${LFS_VERSION%.0}\",
+                    \"body\": $(jq -sR '.' <<< "$CHANGES")
+                }"
+          fi
+
+# Manage statuses
 before_install:
-    - fusermount -V
-    - gcc --version
-
-install:
-    - sudo apt-get install libfuse-dev
-    - git clone --depth 1 https://github.com/geky/littlefs-fuse
-
-before_script:
-    - rm -rf littlefs-fuse/littlefs/*
-    - cp -r $(git ls-tree --name-only HEAD) littlefs-fuse/littlefs
-
-    - mkdir mount
-    - sudo chmod a+rw /dev/loop0
-    - dd if=/dev/zero bs=512 count=2048 of=disk
-    - losetup /dev/loop0 disk
-
-deploy:
-    # Let before_deploy take over
-    provider: script
-    script: 'true'
-    on:
-        branch: master
-
-before_deploy:
-    - cd $TRAVIS_BUILD_DIR
-    # Update tag for version defined in lfs.h
-    - LFS_VERSION=$(grep -ox '#define LFS_VERSION .*' lfs.h | cut -d ' ' -f3)
-    - LFS_VERSION_MAJOR=$((0xffff & ($LFS_VERSION >> 16)))
-    - LFS_VERSION_MINOR=$((0xffff & ($LFS_VERSION >>  0)))
-    - LFS_VERSION="v$LFS_VERSION_MAJOR.$LFS_VERSION_MINOR"
-    - echo "littlefs version $LFS_VERSION"
-    - |
-      curl -u $GEKY_BOT -X POST \
-        https://api.github.com/repos/$TRAVIS_REPO_SLUG/git/refs \
+  - |
+    curl -u $GEKY_BOT_STATUSES -X POST \
+        https://api.github.com/repos/$TRAVIS_REPO_SLUG/statuses/${TRAVIS_PULL_REQUEST_SHA:-$TRAVIS_COMMIT} \
         -d "{
-          \"ref\": \"refs/tags/$LFS_VERSION\",
-          \"sha\": \"$TRAVIS_COMMIT\"
+            \"context\": \"$STAGE/$NAME\",
+            \"state\": \"pending\",
+            \"description\": \"${STATUS:-In progress}\",
+            \"target_url\": \"https://travis-ci.org/$TRAVIS_REPO_SLUG/jobs/$TRAVIS_JOB_ID\"
         }"
-    - |
-      curl -f -u $GEKY_BOT -X PATCH \
-        https://api.github.com/repos/$TRAVIS_REPO_SLUG/git/refs/tags/$LFS_VERSION \
+
+after_failure:
+  - |
+    curl -u $GEKY_BOT_STATUSES -X POST \
+        https://api.github.com/repos/$TRAVIS_REPO_SLUG/statuses/${TRAVIS_PULL_REQUEST_SHA:-$TRAVIS_COMMIT} \
         -d "{
-          \"sha\": \"$TRAVIS_COMMIT\"
+            \"context\": \"$STAGE/$NAME\",
+            \"state\": \"failure\",
+            \"description\": \"${STATUS:-Failed}\",
+            \"target_url\": \"https://travis-ci.org/$TRAVIS_REPO_SLUG/jobs/$TRAVIS_JOB_ID\"
         }"
-    # Create release notes from commits
-    - LFS_PREV_VERSION="v$LFS_VERSION_MAJOR.$(($LFS_VERSION_MINOR-1))"
-    - |
-      if [ $(git tag -l "$LFS_PREV_VERSION") ]
-      then
-        curl -u $GEKY_BOT -X POST \
-            https://api.github.com/repos/$TRAVIS_REPO_SLUG/releases \
-            -d "{
-                \"tag_name\": \"$LFS_VERSION\",
-                \"name\": \"$LFS_VERSION\"
-            }"
-        RELEASE=$(
-            curl -f https://api.github.com/repos/$TRAVIS_REPO_SLUG/releases/tags/$LFS_VERSION
-        )
-        CHANGES=$(
-            git log --oneline $LFS_PREV_VERSION.. --grep='^Merge' --invert-grep
-        )
-        curl -f -u $GEKY_BOT -X PATCH \
-            https://api.github.com/repos/$TRAVIS_REPO_SLUG/releases/$(
-                jq -r '.id' <<< "$RELEASE"
-            ) \
-            -d "$(
-                jq -s '{
-                    "body": ((.[0] // "" | sub("(?<=\n)#+ Changes.*"; ""; "mi"))
-                        + "### Changes\n\n" + .[1])
-                }' <(jq '.body' <<< "$RELEASE") <(jq -sR '.' <<< "$CHANGES")
-            )"
-      fi
+
+after_success:
+  - |
+    curl -u $GEKY_BOT_STATUSES -X POST \
+        https://api.github.com/repos/$TRAVIS_REPO_SLUG/statuses/${TRAVIS_PULL_REQUEST_SHA:-$TRAVIS_COMMIT} \
+        -d "{
+            \"context\": \"$STAGE/$NAME\",
+            \"state\": \"success\",
+            \"description\": \"${STATUS:-Passed}\",
+            \"target_url\": \"https://travis-ci.org/$TRAVIS_REPO_SLUG/jobs/$TRAVIS_JOB_ID\"
+        }"
+
+# Job control
+stages:
+    - name: test
+    - name: deploy
+      if: branch = master AND type = push

--- a/littlefs/LICENSE.md
+++ b/littlefs/LICENSE.md
@@ -1,165 +1,24 @@
-Apache License
-Version 2.0, January 2004
-http://www.apache.org/licenses/
+Copyright (c) 2017, Arm Limited. All rights reserved.
 
-TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
 
-1. Definitions.
+-  Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+-  Redistributions in binary form must reproduce the above copyright notice, this
+   list of conditions and the following disclaimer in the documentation and/or
+   other materials provided with the distribution.
+-  Neither the name of ARM nor the names of its contributors may be used to
+   endorse or promote products derived from this software without specific prior
+   written permission.
 
-"License" shall mean the terms and conditions for use, reproduction, and
-distribution as defined by Sections 1 through 9 of this document.
-
-"Licensor" shall mean the copyright owner or entity authorized by the copyright
-owner that is granting the License.
-
-"Legal Entity" shall mean the union of the acting entity and all other entities
-that control, are controlled by, or are under common control with that entity.
-For the purposes of this definition, "control" means (i) the power, direct or
-indirect, to cause the direction or management of such entity, whether by
-contract or otherwise, or (ii) ownership of fifty percent (50%) or more of the
-outstanding shares, or (iii) beneficial ownership of such entity.
-
-"You" (or "Your") shall mean an individual or Legal Entity exercising
-permissions granted by this License.
-
-"Source" form shall mean the preferred form for making modifications, including
-but not limited to software source code, documentation source, and configuration
-files.
-
-"Object" form shall mean any form resulting from mechanical transformation or
-translation of a Source form, including but not limited to compiled object code,
-generated documentation, and conversions to other media types.
-
-"Work" shall mean the work of authorship, whether in Source or Object form, made
-available under the License, as indicated by a copyright notice that is included
-in or attached to the work (an example is provided in the Appendix below).
-
-"Derivative Works" shall mean any work, whether in Source or Object form, that
-is based on (or derived from) the Work and for which the editorial revisions,
-annotations, elaborations, or other modifications represent, as a whole, an
-original work of authorship. For the purposes of this License, Derivative Works
-shall not include works that remain separable from, or merely link (or bind by
-name) to the interfaces of, the Work and Derivative Works thereof.
-
-"Contribution" shall mean any work of authorship, including the original version
-of the Work and any modifications or additions to that Work or Derivative Works
-thereof, that is intentionally submitted to Licensor for inclusion in the Work
-by the copyright owner or by an individual or Legal Entity authorized to submit
-on behalf of the copyright owner. For the purposes of this definition,
-"submitted" means any form of electronic, verbal, or written communication sent
-to the Licensor or its representatives, including but not limited to
-communication on electronic mailing lists, source code control systems, and
-issue tracking systems that are managed by, or on behalf of, the Licensor for
-the purpose of discussing and improving the Work, but excluding communication
-that is conspicuously marked or otherwise designated in writing by the copyright
-owner as "Not a Contribution."
-
-"Contributor" shall mean Licensor and any individual or Legal Entity on behalf
-of whom a Contribution has been received by Licensor and subsequently
-incorporated within the Work.
-
-2. Grant of Copyright License.
-
-Subject to the terms and conditions of this License, each Contributor hereby
-grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free,
-irrevocable copyright license to reproduce, prepare Derivative Works of,
-publicly display, publicly perform, sublicense, and distribute the Work and such
-Derivative Works in Source or Object form.
-
-3. Grant of Patent License.
-
-Subject to the terms and conditions of this License, each Contributor hereby
-grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free,
-irrevocable (except as stated in this section) patent license to make, have
-made, use, offer to sell, sell, import, and otherwise transfer the Work, where
-such license applies only to those patent claims licensable by such Contributor
-that are necessarily infringed by their Contribution(s) alone or by combination
-of their Contribution(s) with the Work to which such Contribution(s) was
-submitted. If You institute patent litigation against any entity (including a
-cross-claim or counterclaim in a lawsuit) alleging that the Work or a
-Contribution incorporated within the Work constitutes direct or contributory
-patent infringement, then any patent licenses granted to You under this License
-for that Work shall terminate as of the date such litigation is filed.
-
-4. Redistribution.
-
-You may reproduce and distribute copies of the Work or Derivative Works thereof
-in any medium, with or without modifications, and in Source or Object form,
-provided that You meet the following conditions:
-
-You must give any other recipients of the Work or Derivative Works a copy of
-this License; and
-You must cause any modified files to carry prominent notices stating that You
-changed the files; and
-You must retain, in the Source form of any Derivative Works that You distribute,
-all copyright, patent, trademark, and attribution notices from the Source form
-of the Work, excluding those notices that do not pertain to any part of the
-Derivative Works; and
-If the Work includes a "NOTICE" text file as part of its distribution, then any
-Derivative Works that You distribute must include a readable copy of the
-attribution notices contained within such NOTICE file, excluding those notices
-that do not pertain to any part of the Derivative Works, in at least one of the
-following places: within a NOTICE text file distributed as part of the
-Derivative Works; within the Source form or documentation, if provided along
-with the Derivative Works; or, within a display generated by the Derivative
-Works, if and wherever such third-party notices normally appear. The contents of
-the NOTICE file are for informational purposes only and do not modify the
-License. You may add Your own attribution notices within Derivative Works that
-You distribute, alongside or as an addendum to the NOTICE text from the Work,
-provided that such additional attribution notices cannot be construed as
-modifying the License.
-You may add Your own copyright statement to Your modifications and may provide
-additional or different license terms and conditions for use, reproduction, or
-distribution of Your modifications, or for any such Derivative Works as a whole,
-provided Your use, reproduction, and distribution of the Work otherwise complies
-with the conditions stated in this License.
-
-5. Submission of Contributions.
-
-Unless You explicitly state otherwise, any Contribution intentionally submitted
-for inclusion in the Work by You to the Licensor shall be under the terms and
-conditions of this License, without any additional terms or conditions.
-Notwithstanding the above, nothing herein shall supersede or modify the terms of
-any separate license agreement you may have executed with Licensor regarding
-such Contributions.
-
-6. Trademarks.
-
-This License does not grant permission to use the trade names, trademarks,
-service marks, or product names of the Licensor, except as required for
-reasonable and customary use in describing the origin of the Work and
-reproducing the content of the NOTICE file.
-
-7. Disclaimer of Warranty.
-
-Unless required by applicable law or agreed to in writing, Licensor provides the
-Work (and each Contributor provides its Contributions) on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied,
-including, without limitation, any warranties or conditions of TITLE,
-NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A PARTICULAR PURPOSE. You are
-solely responsible for determining the appropriateness of using or
-redistributing the Work and assume any risks associated with Your exercise of
-permissions under this License.
-
-8. Limitation of Liability.
-
-In no event and under no legal theory, whether in tort (including negligence),
-contract, or otherwise, unless required by applicable law (such as deliberate
-and grossly negligent acts) or agreed to in writing, shall any Contributor be
-liable to You for damages, including any direct, indirect, special, incidental,
-or consequential damages of any character arising as a result of this License or
-out of the use or inability to use the Work (including but not limited to
-damages for loss of goodwill, work stoppage, computer failure or malfunction, or
-any and all other commercial damages or losses), even if such Contributor has
-been advised of the possibility of such damages.
-
-9. Accepting Warranty or Additional Liability.
-
-While redistributing the Work or Derivative Works thereof, You may choose to
-offer, and charge a fee for, acceptance of support, warranty, indemnity, or
-other liability obligations and/or rights consistent with this License. However,
-in accepting such obligations, You may act only on Your own behalf and on Your
-sole responsibility, not on behalf of any other Contributor, and only if You
-agree to indemnify, defend, and hold each Contributor harmless for any liability
-incurred by, or claims asserted against, such Contributor by reason of your
-accepting any such warranty or additional liability.
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/littlefs/Makefile
+++ b/littlefs/Makefile
@@ -1,8 +1,11 @@
-TARGET = lfs
+TARGET = lfs.a
+ifneq ($(wildcard test.c main.c),)
+override TARGET = lfs
+endif
 
-CC = gcc
-AR = ar
-SIZE = size
+CC ?= gcc
+AR ?= ar
+SIZE ?= size
 
 SRC += $(wildcard *.c emubd/*.c)
 OBJ := $(SRC:.c=.o)
@@ -22,7 +25,7 @@ ifdef WORD
 override CFLAGS += -m$(WORD)
 endif
 override CFLAGS += -I.
-override CFLAGS += -std=c99 -Wall -pedantic
+override CFLAGS += -std=c99 -Wall -pedantic -Wshadow -Wunused-parameter
 
 
 all: $(TARGET)
@@ -33,9 +36,11 @@ size: $(OBJ)
 	$(SIZE) -t $^
 
 .SUFFIXES:
-test: test_format test_dirs test_files test_seek test_truncate test_parallel \
-	test_alloc test_paths test_orphan test_move test_corrupt
+test: test_format test_dirs test_files test_seek test_truncate \
+	test_interspersed test_alloc test_paths test_orphan test_move test_corrupt
+	@rm test.c
 test_%: tests/test_%.sh
+
 ifdef QUIET
 	@./$< | sed -n '/^[-=]/p'
 else
@@ -44,7 +49,7 @@ endif
 
 -include $(DEP)
 
-$(TARGET): $(OBJ)
+lfs: $(OBJ)
 	$(CC) $(CFLAGS) $^ $(LFLAGS) -o $@
 
 %.a: $(OBJ)

--- a/littlefs/README.md
+++ b/littlefs/README.md
@@ -115,10 +115,17 @@ All littlefs have the potential to return a negative error code. The errors
 can be either one of those found in the `enum lfs_error` in [lfs.h](lfs.h),
 or an error returned by the user's block device operations.
 
-It should also be noted that the current implementation of littlefs doesn't
-really do anything to ensure that the data written to disk is machine portable.
-This is fine as long as all of the involved machines share endianness
-(little-endian) and don't have strange padding requirements.
+In the configuration struct, the `prog` and `erase` function provided by the
+user may return a `LFS_ERR_CORRUPT` error if the implementation already can
+detect corrupt blocks. However, the wear leveling does not depend on the return
+code of these functions, instead all data is read back and checked for
+integrity.
+
+If your storage caches writes, make sure that the provided `sync` function
+flushes all the data to memory and ensures that the next read fetches the data
+from memory, otherwise data integrity can not be guaranteed. If the `write`
+function does not perform caching, and therefore each `read` or `write` call
+hits the memory, the `sync` function can simply return 0.
 
 ## Reference material
 
@@ -138,6 +145,19 @@ The tests assume a Linux environment and can be started with make:
 ``` bash
 make test
 ```
+
+## License
+
+The littlefs is provided under the [BSD-3-Clause](https://spdx.org/licenses/BSD-3-Clause.html)
+license. See [LICENSE.md](LICENSE.md) for more information. Contributions to
+this project are accepted under the same license.
+
+Individual files contain the following tag instead of the full license text.
+
+    SPDX-License-Identifier:    BSD-3-Clause
+
+This enables machine processing of license information based on the SPDX
+License Identifiers that are here available: http://spdx.org/licenses/
 
 ## Related projects
 

--- a/littlefs/emubd/lfs_emubd.c
+++ b/littlefs/emubd/lfs_emubd.c
@@ -1,19 +1,8 @@
 /*
  * Block device emulated on standard files
  *
- * Copyright (c) 2017 ARM Limited
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Copyright (c) 2017, Arm Limited. All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 #include "emubd/lfs_emubd.h"
 
@@ -27,6 +16,7 @@
 #include <unistd.h>
 #include <assert.h>
 #include <stdbool.h>
+#include <inttypes.h>
 
 
 // Block device emulated on existing filesystem
@@ -96,7 +86,7 @@ int lfs_emubd_read(const struct lfs_config *cfg, lfs_block_t block,
     memset(data, 0, size);
 
     // Read data
-    snprintf(emu->child, LFS_NAME_MAX, "%x", block);
+    snprintf(emu->child, LFS_NAME_MAX, "%" PRIx32, block);
 
     FILE *f = fopen(emu->path, "rb");
     if (!f && errno != ENOENT) {
@@ -135,7 +125,7 @@ int lfs_emubd_prog(const struct lfs_config *cfg, lfs_block_t block,
     assert(block < cfg->block_count);
 
     // Program data
-    snprintf(emu->child, LFS_NAME_MAX, "%x", block);
+    snprintf(emu->child, LFS_NAME_MAX, "%" PRIx32, block);
 
     FILE *f = fopen(emu->path, "r+b");
     if (!f) {
@@ -182,7 +172,7 @@ int lfs_emubd_erase(const struct lfs_config *cfg, lfs_block_t block) {
     assert(block < cfg->block_count);
 
     // Erase the block
-    snprintf(emu->child, LFS_NAME_MAX, "%x", block);
+    snprintf(emu->child, LFS_NAME_MAX, "%" PRIx32, block);
     struct stat st;
     int err = stat(emu->path, &st);
     if (err && errno != ENOENT) {
@@ -250,4 +240,3 @@ int lfs_emubd_sync(const struct lfs_config *cfg) {
 
     return 0;
 }
-

--- a/littlefs/emubd/lfs_emubd.h
+++ b/littlefs/emubd/lfs_emubd.h
@@ -1,25 +1,19 @@
 /*
  * Block device emulated on standard files
  *
- * Copyright (c) 2017 ARM Limited
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Copyright (c) 2017, Arm Limited. All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 #ifndef LFS_EMUBD_H
 #define LFS_EMUBD_H
 
 #include "lfs.h"
 #include "lfs_util.h"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
 
 
 // Config options
@@ -85,5 +79,9 @@ int lfs_emubd_erase(const struct lfs_config *cfg, lfs_block_t block);
 // Sync the block device
 int lfs_emubd_sync(const struct lfs_config *cfg);
 
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
 
 #endif

--- a/littlefs/lfs.h
+++ b/littlefs/lfs.h
@@ -1,19 +1,8 @@
 /*
  * The little filesystem
  *
- * Copyright (c) 2017 ARM Limited
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Copyright (c) 2017, Arm Limited. All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 #ifndef LFS_H
 #define LFS_H
@@ -21,13 +10,18 @@
 #include <stdint.h>
 #include <stdbool.h>
 
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
 
 /// Version info ///
 
 // Software library version
 // Major (top-nibble), incremented on backwards incompatible changes
 // Minor (bottom-nibble), incremented on feature additions
-#define LFS_VERSION 0x00010002
+#define LFS_VERSION 0x00010006
 #define LFS_VERSION_MAJOR (0xffff & (LFS_VERSION >> 16))
 #define LFS_VERSION_MINOR (0xffff & (LFS_VERSION >>  0))
 
@@ -173,6 +167,12 @@ struct lfs_config {
     void *file_buffer;
 };
 
+// Optional configuration provided during lfs_file_opencfg
+struct lfs_file_config {
+    // Optional, statically allocated buffer for files. Must be program sized.
+    // If NULL, malloc will be used by default.
+    void *buffer;
+};
 
 // File info structure
 struct lfs_info {
@@ -220,6 +220,7 @@ typedef struct lfs_file {
     lfs_block_t head;
     lfs_size_t size;
 
+    const struct lfs_file_config *cfg;
     uint32_t flags;
     lfs_off_t pos;
     lfs_block_t block;
@@ -259,9 +260,9 @@ typedef struct lfs_superblock {
 } lfs_superblock_t;
 
 typedef struct lfs_free {
-    lfs_block_t begin;
-    lfs_block_t size;
     lfs_block_t off;
+    lfs_block_t size;
+    lfs_block_t i;
     lfs_block_t ack;
     uint32_t *buffer;
 } lfs_free_t;
@@ -287,7 +288,8 @@ typedef struct lfs {
 // Format a block device with the littlefs
 //
 // Requires a littlefs object and config struct. This clobbers the littlefs
-// object, and does not leave the filesystem mounted.
+// object, and does not leave the filesystem mounted. The config struct must
+// be zeroed for defaults and backwards compatibility.
 //
 // Returns a negative error code on failure.
 int lfs_format(lfs_t *lfs, const struct lfs_config *config);
@@ -296,7 +298,8 @@ int lfs_format(lfs_t *lfs, const struct lfs_config *config);
 //
 // Requires a littlefs object and config struct. Multiple filesystems
 // may be mounted simultaneously with multiple littlefs objects. Both
-// lfs and config must be allocated while mounted.
+// lfs and config must be allocated while mounted. The config struct must
+// be zeroed for defaults and backwards compatibility.
 //
 // Returns a negative error code on failure.
 int lfs_mount(lfs_t *lfs, const struct lfs_config *config);
@@ -320,10 +323,6 @@ int lfs_remove(lfs_t *lfs, const char *path);
 // If the destination exists, it must match the source in type.
 // If the destination is a directory, the directory must be empty.
 //
-// Note: If power loss occurs, it is possible that the file or directory
-// will exist in both the oldpath and newpath simultaneously after the
-// next mount.
-//
 // Returns a negative error code on failure.
 int lfs_rename(lfs_t *lfs, const char *oldpath, const char *newpath);
 
@@ -338,13 +337,26 @@ int lfs_stat(lfs_t *lfs, const char *path, struct lfs_info *info);
 
 // Open a file
 //
-// The mode that the file is opened in is determined
-// by the flags, which are values from the enum lfs_open_flags
-// that are bitwise-ored together.
+// The mode that the file is opened in is determined by the flags, which
+// are values from the enum lfs_open_flags that are bitwise-ored together.
 //
 // Returns a negative error code on failure.
 int lfs_file_open(lfs_t *lfs, lfs_file_t *file,
         const char *path, int flags);
+
+// Open a file with extra configuration
+//
+// The mode that the file is opened in is determined by the flags, which
+// are values from the enum lfs_open_flags that are bitwise-ored together.
+//
+// The config struct provides additional config options per file as described
+// above. The config struct must be allocated while the file is open, and the
+// config struct must be zeroed for defaults and backwards compatibility.
+//
+// Returns a negative error code on failure.
+int lfs_file_opencfg(lfs_t *lfs, lfs_file_t *file,
+        const char *path, int flags,
+        const struct lfs_file_config *config);
 
 // Close a file
 //
@@ -474,5 +486,9 @@ int lfs_traverse(lfs_t *lfs, int (*cb)(void*, lfs_block_t), void *data);
 // Returns a negative error code on failure.
 int lfs_deorphan(lfs_t *lfs);
 
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
 
 #endif

--- a/littlefs/lfs_util.c
+++ b/littlefs/lfs_util.c
@@ -1,23 +1,16 @@
 /*
  * lfs util functions
  *
- * Copyright (c) 2017 ARM Limited
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Copyright (c) 2017, Arm Limited. All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 #include "lfs_util.h"
 
+// Only compile if user does not provide custom config
+#ifndef LFS_CONFIG
 
+
+// Software CRC implementation with small lookup table
 void lfs_crc(uint32_t *restrict crc, const void *buffer, size_t size) {
     static const uint32_t rtable[16] = {
         0x00000000, 0x1db71064, 0x3b6e20c8, 0x26d930ac,
@@ -34,3 +27,5 @@ void lfs_crc(uint32_t *restrict crc, const void *buffer, size_t size) {
     }
 }
 
+
+#endif

--- a/littlefs/lfs_util.h
+++ b/littlefs/lfs_util.h
@@ -1,30 +1,84 @@
 /*
  * lfs utility functions
  *
- * Copyright (c) 2017 ARM Limited
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Copyright (c) 2017, Arm Limited. All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 #ifndef LFS_UTIL_H
 #define LFS_UTIL_H
 
-#include <stdlib.h>
+// Users can override lfs_util.h with their own configuration by defining
+// LFS_CONFIG as a header file to include (-DLFS_CONFIG=lfs_config.h).
+//
+// If LFS_CONFIG is used, none of the default utils will be emitted and must be
+// provided by the config file. To start I would suggest copying lfs_util.h and
+// modifying as needed.
+#ifdef LFS_CONFIG
+#define LFS_STRINGIZE(x) LFS_STRINGIZE2(x)
+#define LFS_STRINGIZE2(x) #x
+#include LFS_STRINGIZE(LFS_CONFIG)
+#else
+
+// System includes
 #include <stdint.h>
+#include <stdbool.h>
+#include <string.h>
+
+#ifndef LFS_NO_MALLOC
+#include <stdlib.h>
+#endif
+#ifndef LFS_NO_ASSERT
+#include <assert.h>
+#endif
+#if !defined(LFS_NO_DEBUG) || !defined(LFS_NO_WARN) || !defined(LFS_NO_ERROR)
 #include <stdio.h>
+#endif
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
 
 
-// Builtin functions, these may be replaced by more
-// efficient implementations in the system
+// Macros, may be replaced by system specific wrappers. Arguments to these
+// macros must not have side-effects as the macros can be removed for a smaller
+// code footprint
+
+// Logging functions
+#ifndef LFS_NO_DEBUG
+#define LFS_DEBUG(fmt, ...) \
+    fprintf(stderr, "lfs debug:%d: " fmt "\n", __LINE__, __VA_ARGS__)
+#else
+#define LFS_DEBUG(fmt, ...)
+#endif
+
+#ifndef LFS_NO_WARN
+#define LFS_WARN(fmt, ...) \
+    fprintf(stderr, "lfs warn:%d: " fmt "\n", __LINE__, __VA_ARGS__)
+#else
+#define LFS_WARN(fmt, ...)
+#endif
+
+#ifndef LFS_NO_ERROR
+#define LFS_ERROR(fmt, ...) \
+    fprintf(stderr, "lfs error:%d: " fmt "\n", __LINE__, __VA_ARGS__)
+#else
+#define LFS_ERROR(fmt, ...)
+#endif
+
+// Runtime assertions
+#ifndef LFS_NO_ASSERT
+#define LFS_ASSERT(test) assert(test)
+#else
+#define LFS_ASSERT(test)
+#endif
+
+
+// Builtin functions, these may be replaced by more efficient
+// toolchain-specific implementations. LFS_NO_INTRINSICS falls back to a more
+// expensive basic C implementation for debugging purposes
+
+// Min/max functions for unsigned 32-bit numbers
 static inline uint32_t lfs_max(uint32_t a, uint32_t b) {
     return (a > b) ? a : b;
 }
@@ -33,31 +87,100 @@ static inline uint32_t lfs_min(uint32_t a, uint32_t b) {
     return (a < b) ? a : b;
 }
 
-static inline uint32_t lfs_ctz(uint32_t a) {
-    return __builtin_ctz(a);
-}
-
+// Find the next smallest power of 2 less than or equal to a
 static inline uint32_t lfs_npw2(uint32_t a) {
+#if !defined(LFS_NO_INTRINSICS) && (defined(__GNUC__) || defined(__CC_ARM))
     return 32 - __builtin_clz(a-1);
+#else
+    uint32_t r = 0;
+    uint32_t s;
+    a -= 1;
+    s = (a > 0xffff) << 4; a >>= s; r |= s;
+    s = (a > 0xff  ) << 3; a >>= s; r |= s;
+    s = (a > 0xf   ) << 2; a >>= s; r |= s;
+    s = (a > 0x3   ) << 1; a >>= s; r |= s;
+    return (r | (a >> 1)) + 1;
+#endif
 }
 
+// Count the number of trailing binary zeros in a
+// lfs_ctz(0) may be undefined
+static inline uint32_t lfs_ctz(uint32_t a) {
+#if !defined(LFS_NO_INTRINSICS) && defined(__GNUC__)
+    return __builtin_ctz(a);
+#else
+    return lfs_npw2((a & -a) + 1) - 1;
+#endif
+}
+
+// Count the number of binary ones in a
 static inline uint32_t lfs_popc(uint32_t a) {
+#if !defined(LFS_NO_INTRINSICS) && (defined(__GNUC__) || defined(__CC_ARM))
     return __builtin_popcount(a);
+#else
+    a = a - ((a >> 1) & 0x55555555);
+    a = (a & 0x33333333) + ((a >> 2) & 0x33333333);
+    return (((a + (a >> 4)) & 0xf0f0f0f) * 0x1010101) >> 24;
+#endif
 }
 
+// Find the sequence comparison of a and b, this is the distance
+// between a and b ignoring overflow
 static inline int lfs_scmp(uint32_t a, uint32_t b) {
     return (int)(unsigned)(a - b);
 }
 
-// CRC-32 with polynomial = 0x04c11db7
+// Convert from 32-bit little-endian to native order
+static inline uint32_t lfs_fromle32(uint32_t a) {
+#if !defined(LFS_NO_INTRINSICS) && ( \
+    (defined(  BYTE_ORDER  ) &&   BYTE_ORDER   ==   ORDER_LITTLE_ENDIAN  ) || \
+    (defined(__BYTE_ORDER  ) && __BYTE_ORDER   == __ORDER_LITTLE_ENDIAN  ) || \
+    (defined(__BYTE_ORDER__) && __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__))
+    return a;
+#elif !defined(LFS_NO_INTRINSICS) && ( \
+    (defined(  BYTE_ORDER  ) &&   BYTE_ORDER   ==   ORDER_BIG_ENDIAN  ) || \
+    (defined(__BYTE_ORDER  ) && __BYTE_ORDER   == __ORDER_BIG_ENDIAN  ) || \
+    (defined(__BYTE_ORDER__) && __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__))
+    return __builtin_bswap32(a);
+#else
+    return (((uint8_t*)&a)[0] <<  0) |
+           (((uint8_t*)&a)[1] <<  8) |
+           (((uint8_t*)&a)[2] << 16) |
+           (((uint8_t*)&a)[3] << 24);
+#endif
+}
+
+// Convert to 32-bit little-endian from native order
+static inline uint32_t lfs_tole32(uint32_t a) {
+    return lfs_fromle32(a);
+}
+
+// Calculate CRC-32 with polynomial = 0x04c11db7
 void lfs_crc(uint32_t *crc, const void *buffer, size_t size);
 
+// Allocate memory, only used if buffers are not provided to littlefs
+static inline void *lfs_malloc(size_t size) {
+#ifndef LFS_NO_MALLOC
+    return malloc(size);
+#else
+    (void)size;
+    return NULL;
+#endif
+}
 
-// Logging functions, these may be replaced by system-specific
-// logging functions
-#define LFS_DEBUG(fmt, ...) fprintf(stderr, "lfs debug: " fmt "\n", __VA_ARGS__)
-#define LFS_WARN(fmt, ...)  fprintf(stderr, "lfs warn: " fmt "\n", __VA_ARGS__)
-#define LFS_ERROR(fmt, ...) fprintf(stderr, "lfs error: " fmt "\n", __VA_ARGS__)
+// Deallocate memory, only used if buffers are not provided to littlefs
+static inline void lfs_free(void *p) {
+#ifndef LFS_NO_MALLOC
+    free(p);
+#else
+    (void)p;
+#endif
+}
 
 
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
+
+#endif
 #endif

--- a/littlefs/tests/test.py
+++ b/littlefs/tests/test.py
@@ -33,10 +33,15 @@ def generate(test):
         pass
 
 def compile():
-    subprocess.check_call(['make', '--no-print-directory', '-s'])
+    subprocess.check_call([
+            os.environ.get('MAKE', 'make'),
+            '--no-print-directory', '-s'])
 
 def execute():
-    subprocess.check_call(["./lfs"])
+    if 'EXEC' in os.environ:
+        subprocess.check_call([os.environ['EXEC'], "./lfs"])
+    else:
+        subprocess.check_call(["./lfs"])
 
 def main(test=None):
     if test and not test.startswith('-'):

--- a/littlefs/tests/test_files.sh
+++ b/littlefs/tests/test_files.sh
@@ -30,7 +30,7 @@ TEST
 
 w_test() {
 tests/test.py << TEST
-    lfs_size_t size = $1;
+    size = $1;
     lfs_size_t chunk = 31;
     srand(0);
     lfs_mount(&lfs, &cfg) => 0;
@@ -50,7 +50,7 @@ TEST
 
 r_test() {
 tests/test.py << TEST
-    lfs_size_t size = $1;
+    size = $1;
     lfs_size_t chunk = 29;
     srand(0);
     lfs_mount(&lfs, &cfg) => 0;
@@ -132,6 +132,25 @@ tests/test.py << TEST
     info.size => 0;
     lfs_dir_read(&lfs, &dir[0], &info) => 0;
     lfs_dir_close(&lfs, &dir[0]) => 0;
+    lfs_unmount(&lfs) => 0;
+TEST
+
+echo "--- Many file test ---"
+tests/test.py << TEST
+    lfs_format(&lfs, &cfg) => 0;
+TEST
+tests/test.py << TEST
+    // Create 300 files of 6 bytes
+    lfs_mount(&lfs, &cfg) => 0;
+    lfs_mkdir(&lfs, "directory") => 0;
+    for (unsigned i = 0; i < 300; i++) {
+        snprintf((char*)buffer, sizeof(buffer), "file_%03d", i);
+        lfs_file_open(&lfs, &file[0], (char*)buffer, LFS_O_WRONLY | LFS_O_CREAT) => 0;
+        size = 6;
+        memcpy(wbuffer, "Hello", size);
+        lfs_file_write(&lfs, &file[0], wbuffer, size) => size;
+        lfs_file_close(&lfs, &file[0]) => 0;
+    }
     lfs_unmount(&lfs) => 0;
 TEST
 

--- a/littlefs/tests/test_interspersed.sh
+++ b/littlefs/tests/test_interspersed.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
 set -eu
 
-echo "=== Parallel tests ==="
+echo "=== Interspersed tests ==="
 rm -rf blocks
 tests/test.py << TEST
     lfs_format(&lfs, &cfg) => 0;
 TEST
 
-echo "--- Parallel file test ---"
+echo "--- Interspersed file test ---"
 tests/test.py << TEST
     lfs_mount(&lfs, &cfg) => 0;
     lfs_file_open(&lfs, &file[0], "a", LFS_O_WRONLY | LFS_O_CREAT) => 0;
@@ -77,7 +77,7 @@ tests/test.py << TEST
     lfs_unmount(&lfs) => 0;
 TEST
 
-echo "--- Parallel remove file test ---"
+echo "--- Interspersed remove file test ---"
 tests/test.py << TEST
     lfs_mount(&lfs, &cfg) => 0;
     lfs_file_open(&lfs, &file[0], "e", LFS_O_WRONLY | LFS_O_CREAT) => 0;

--- a/littlefs/tests/test_paths.sh
+++ b/littlefs/tests/test_paths.sh
@@ -90,6 +90,22 @@ tests/test.py << TEST
     lfs_unmount(&lfs) => 0;
 TEST
 
+echo "--- Trailing dot path tests ---"
+tests/test.py << TEST
+    lfs_mount(&lfs, &cfg) => 0;
+    lfs_stat(&lfs, "tea/hottea/", &info) => 0;
+    strcmp(info.name, "hottea") => 0;
+    lfs_stat(&lfs, "tea/hottea/.", &info) => 0;
+    strcmp(info.name, "hottea") => 0;
+    lfs_stat(&lfs, "tea/hottea/./.", &info) => 0;
+    strcmp(info.name, "hottea") => 0;
+    lfs_stat(&lfs, "tea/hottea/..", &info) => 0;
+    strcmp(info.name, "tea") => 0;
+    lfs_stat(&lfs, "tea/hottea/../.", &info) => 0;
+    strcmp(info.name, "tea") => 0;
+    lfs_unmount(&lfs) => 0;
+TEST
+
 echo "--- Root dot dot path tests ---"
 tests/test.py << TEST
     lfs_mount(&lfs, &cfg) => 0;
@@ -108,6 +124,10 @@ tests/test.py << TEST
     lfs_stat(&lfs, "/", &info) => 0;
     info.type => LFS_TYPE_DIR;
     strcmp(info.name, "/") => 0;
+
+    lfs_mkdir(&lfs, "/") => LFS_ERR_EXIST;
+    lfs_file_open(&lfs, &file[0], "/", LFS_O_WRONLY | LFS_O_CREAT)
+        => LFS_ERR_ISDIR;
     lfs_unmount(&lfs) => 0;
 TEST
 

--- a/littlefs/tests/test_seek.sh
+++ b/littlefs/tests/test_seek.sh
@@ -153,7 +153,7 @@ tests/test.py << TEST
     lfs_file_read(&lfs, &file[0], buffer, size) => size;
     memcmp(buffer, "kittycatcat", size) => 0;
 
-    lfs_size_t size = lfs_file_size(&lfs, &file[0]);
+    size = lfs_file_size(&lfs, &file[0]);
     lfs_file_seek(&lfs, &file[0], 0, LFS_SEEK_CUR) => size;
 
     lfs_file_close(&lfs, &file[0]) => 0;
@@ -202,7 +202,7 @@ tests/test.py << TEST
     lfs_file_read(&lfs, &file[0], buffer, size) => size;
     memcmp(buffer, "kittycatcat", size) => 0;
 
-    lfs_size_t size = lfs_file_size(&lfs, &file[0]);
+    size = lfs_file_size(&lfs, &file[0]);
     lfs_file_seek(&lfs, &file[0], 0, LFS_SEEK_CUR) => size;
 
     lfs_file_close(&lfs, &file[0]) => 0;
@@ -243,7 +243,7 @@ tests/test.py << TEST
     lfs_file_read(&lfs, &file[0], buffer, size) => size;
     memcmp(buffer, "kittycatcat", size) => 0;
 
-    lfs_size_t size = lfs_file_size(&lfs, &file[0]);
+    size = lfs_file_size(&lfs, &file[0]);
     lfs_file_seek(&lfs, &file[0], 0, LFS_SEEK_CUR) => size;
 
     lfs_file_close(&lfs, &file[0]) => 0;
@@ -286,7 +286,7 @@ tests/test.py << TEST
     lfs_file_read(&lfs, &file[0], buffer, size) => size;
     memcmp(buffer, "kittycatcat", size) => 0;
 
-    lfs_size_t size = lfs_file_size(&lfs, &file[0]);
+    size = lfs_file_size(&lfs, &file[0]);
     lfs_file_seek(&lfs, &file[0], 0, LFS_SEEK_CUR) => size;
 
     lfs_file_close(&lfs, &file[0]) => 0;


### PR DESCRIPTION
This brings the littlefs implementation up to version 1.6.

Note! This includes a change in the license to use the [BSD-3-Clause](https://spdx.org/licenses/BSD-3-Clause.html) license. More info here: https://github.com/ARMmbed/littlefs/issues/59

Here is the full set of changes:
[`510cd13`](https://github.com/armmbed/littlefs/commit/510cd13) Bumped minor version to v1.6
[`f5e0539`](https://github.com/armmbed/littlefs/commit/f5e0539) Fixed issue with release script non-standard version tags
[`0664480`](https://github.com/armmbed/littlefs/commit/0664480) Moved SPDX and license info into README
[`0234c77`](https://github.com/armmbed/littlefs/commit/0234c77) Simplified release process based on feedback
[`0422c55`](https://github.com/armmbed/littlefs/commit/0422c55) Fix memory leaks in lfs_mount and lfs_format
[`961fab7`](https://github.com/armmbed/littlefs/commit/961fab7) Added file config structure and lfs_file_opencfg
[`041e90a`](https://github.com/armmbed/littlefs/commit/041e90a) Added handling for corrupt as initial state of blocks
[`577d777`](https://github.com/armmbed/littlefs/commit/577d777) Add C++ guards to public headers
[`7e67f93`](https://github.com/armmbed/littlefs/commit/7e67f93) Use PRIu32 and PRIx32 format specifiers to fix warnings
[`5a17fa4`](https://github.com/armmbed/littlefs/commit/5a17fa4) Fixed script issue with bash expansion inside makefile parameter
[`eed1eec`](https://github.com/armmbed/littlefs/commit/eed1eec) Fixed information leaks through reused caches
[`4a86370`](https://github.com/armmbed/littlefs/commit/4a86370) Added quality of life improvements for main.c/test.c issues
[`51346b8`](https://github.com/armmbed/littlefs/commit/51346b8) Fixed shadowed variable warnings
[`6beff50`](https://github.com/armmbed/littlefs/commit/6beff50) Changed license to BSD-3-Clause
[`c5e2b33`](https://github.com/armmbed/littlefs/commit/c5e2b33) Added error when opening multiple files with a statically allocated buffer
[`015b86b`](https://github.com/armmbed/littlefs/commit/015b86b) Fixed issue with trailing dots in file paths
[`9637b96`](https://github.com/armmbed/littlefs/commit/9637b96) Fixed lookahead overflow and removed unbounded lookahead pointers
[`89a7630`](https://github.com/armmbed/littlefs/commit/89a7630) Fixed issue with lookahead trusting old lookahead blocks
[`43eac30`](https://github.com/armmbed/littlefs/commit/43eac30) Renamed test_parallel tests to test_interespersed
[`dbc3cb1`](https://github.com/armmbed/littlefs/commit/dbc3cb1) Fixed Travis rate-limit issue with Github requests
[`93ece2e`](https://github.com/armmbed/littlefs/commit/93ece2e) Removed outdated note about moves and powerloss
[`d9c076d`](https://github.com/armmbed/littlefs/commit/d9c076d) Removed the uninitialized read for invalid superblocks
[`f72f6d6`](https://github.com/armmbed/littlefs/commit/f72f6d6) Removed out of date note about endianness
[`5c4ee21`](https://github.com/armmbed/littlefs/commit/5c4ee21) Added a note about the callback functions
[`1552246`](https://github.com/armmbed/littlefs/commit/1552246) Fixed Travis issue with deploy stage in PRs
[`9ee112a`](https://github.com/armmbed/littlefs/commit/9ee112a) Fixed issue updating dir struct when extended dir chain
[`d9c3637`](https://github.com/armmbed/littlefs/commit/d9c3637) Fixed handling of root as target for create operations
[`1476181`](https://github.com/armmbed/littlefs/commit/1476181) Added LFS_CONFIG for user provided configuration of the utils
[`b2124a5`](https://github.com/geky/littlefs/commit/b2124a5) Fixed multiple deploy steps in Travis
[`67daf9e`](https://github.com/geky/littlefs/commit/67daf9e) Added cross-compile targets for testing
[`a3fd2d4`](https://github.com/geky/littlefs/commit/a3fd2d4) Added more configurable utils
[`a0a55fb`](https://github.com/geky/littlefs/commit/a0a55fb) Added conversion to/from little-endian on disk
[`4f08424`](https://github.com/geky/littlefs/commit/4f08424) Added software implementations of bitwise instructions
[`2f8ae34`](https://github.com/geky/littlefs/commit/2f8ae34) Added a git ignore file with .o .d blocks dir and lfs bin
