### PR TITLE
Remove stropts.h for sys/ioctl.h

### DIFF
--- a/lfs_fuse_bd.c
+++ b/lfs_fuse_bd.c
@@ -12,7 +12,7 @@
 #include <stdint.h>
 #include <assert.h>
 #if !defined(__FreeBSD__)
-#include <stropts.h>
+#include <sys/ioctl.h>
 #include <linux/fs.h>
 #elif defined(__FreeBSD__)
 #define BLKSSZGET DIOCGSECTORSIZE


### PR DESCRIPTION
See https://github.com/ARMmbed/littlefs-fuse/issues/8

> Apparently stropts.h has not been distributed in Fedora for about a decade, so probably it should be removed.

It looks like this was bringing in ioctl on Linux. It looks like "sys/ioctl.h" should be the correct path.

cc @armijnhemel
should resolve #8